### PR TITLE
Bug imagemagick rhel9

### DIFF
--- a/nimbix_desktop/install-rhel-desktop.sh
+++ b/nimbix_desktop/install-rhel-desktop.sh
@@ -19,7 +19,7 @@ elif [[ "${VERSION_ID:0:1}" == "8" ]] || [[ "${VERSION_ID:0:1}" == "9" ]]; then
     dnf install dnf-plugins-core -y
     if [[ "${VERSION_ID:0:1}" == "8" ]]; then
         dnf config-manager --set-enabled powertools
-        dnf install -y xorg-x11-apps pygtk2
+        dnf install -y xorg-x11-apps pygtk2 ImageMagick-devel
     elif [[ "${VERSION_ID:0:1}" == "9" ]]; then
         dnf config-manager --set-enabled crb
         dnf install dbus-x11 -y
@@ -29,7 +29,7 @@ elif [[ "${VERSION_ID:0:1}" == "8" ]] || [[ "${VERSION_ID:0:1}" == "9" ]]; then
        xorg-x11-fonts-Type1 xorg-x11-fonts-misc xorg-x11-fonts-75dpi xorg-x11-fonts-100dpi \
        xorg-x11-fonts-ISO8859-1-100dpi xorg-x11-fonts-ISO8859-1-75dpi \
        xkeyboard-config xterm xcb-util xcb-util-keysyms xorg-x11-utils \
-       net-tools glx-utils ImageMagick-devel firefox \
+       net-tools glx-utils firefox \
        ristretto xterm python3-numpy python3-gobject python3-pip libGLU $RIS
     # Remove power manager to prevent pannel plugin crash at startup
     dnf -y remove xfce4-power-manager

--- a/nimbix_desktop/install-rhel-desktop.sh
+++ b/nimbix_desktop/install-rhel-desktop.sh
@@ -12,17 +12,17 @@ if [[ "${VERSION_ID:0:1}" == "7" ]]; then
        xorg-x11-fonts-Type1 xorg-x11-fonts-misc xorg-x11-fonts-75dpi xorg-x11-fonts-100dpi \
        xorg-x11-fonts-ISO8859-1-100dpi xorg-x11-fonts-ISO8859-1-75dpi \
        xkeyboard-config xorg-x11-apps xcb-util xcb-util-keysyms xorg-x11-utils \
-       net-tools glx-utils ImageMagick-devel firefox  \
+       net-tools glx-utils firefox  \
        ristretto xterm numpy python36-numpy python36-gobject python-pip
 elif [[ "${VERSION_ID:0:1}" == "8" ]] || [[ "${VERSION_ID:0:1}" == "9" ]]; then
     dnf install 'dnf-command(config-manager)' -y
     dnf install dnf-plugins-core -y
     if [[ "${VERSION_ID:0:1}" == "8" ]]; then
         dnf config-manager --set-enabled powertools
-        dnf install -y xorg-x11-apps pygtk2 ImageMagick-devel
+        dnf install -y xorg-x11-apps pygtk2
     elif [[ "${VERSION_ID:0:1}" == "9" ]]; then
         dnf config-manager --set-enabled crb
-        dnf install dbus-x11 -y
+        dnf install dbus-x11 xwd -y
     fi
     dnf -y groupinstall Xfce --nobest
     dnf -y install perl wget xauth adwaita-icon-theme  \


### PR DESCRIPTION
Bug with ImageMagick with Rocky Linux 9.
Removed ImageMagick from rhel.
Needed package `/usr/bin/xwd` added manually:
* RHEL 8 -> xorg-x11-apps
* RHEL 9 -> xwd